### PR TITLE
Week11 use reducer use context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ function App() {
 
   useEffect(() => {
     const fetchTodos = async () => {
+      dispatch({ type: todoActions.fetchTodos });
       setIsLoading(true);
       const options = {
         method: 'GET',
@@ -51,6 +52,7 @@ function App() {
         if (!resp.ok)
           throw new Error('NetworkError when attempting to fetch resource.');
         const { records } = await resp.json();
+        dispatch({ type: todoActions.loadTodos, records });
         const mapped = records.map((record) => ({
           id: record.id,
           title: record.fields?.title ?? '',
@@ -58,6 +60,7 @@ function App() {
         }));
         setTodoList(mapped);
       } catch (error) {
+        dispatch({ type: todoActions.setLoadError, error });
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
         setIsLoading(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import {
   reducer as todosReducer,
   actions as todoActions,
   initialState as initialTodosState,
-} from './reducers/todos.reducer';
+} from './features/reducers/todos.reducer';
 
 function App() {
   const [todoState, dispatch] = useReducer(todosReducer, initialTodosState);
@@ -71,6 +71,7 @@ function App() {
 
   const addTodo = async (title) => {
     const newTodo = { title, isCompleted: false };
+    dispatch({ type: todoActions.startRequest });
 
     const payload = {
       records: [
@@ -98,6 +99,7 @@ function App() {
       if (!resp.ok)
         throw new Error('NetworkError when attempting to fetch resource.');
       const { records } = await resp.json();
+      dispatch({ type: todoActions.addTodo, records });
 
       const savedTodo = {
         id: records[0].id,
@@ -107,8 +109,10 @@ function App() {
 
       setTodoList((prev) => [...prev, savedTodo]);
     } catch (error) {
+      dispatch({ type: todoActions.setLoadError, error });
       setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
+      dispatch({ type: todoActions.endRequest });
       setIsSaving(false);
     }
   };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,12 +217,12 @@ function App() {
         <img src={logo} alt="" className={styles.logo} />
         Todo List
       </h1>
-      <TodoForm onAddTodo={addTodo} isSaving={isSaving} />
+      <TodoForm onAddTodo={addTodo} isSaving={todoState.isSaving} />
       <TodoList
-        todoList={todoList}
+        todoList={todoState.todoList}
         onCompleteTodo={completeTodo}
         onUpdateTodo={updateTodo}
-        isLoading={isLoading}
+        isLoading={todoState.isLoading}
       />
 
       <hr />
@@ -235,13 +235,13 @@ function App() {
         setQueryString={setQueryString}
       />
 
-      {errorMessage && (
+      {todoState.errorMessage && (
         <div role="alert" className={styles.errorBox}>
           <div className={styles.errorRow}>
             <img src={errorIcon} alt="" className={styles.errorIcon} />
-            <p>{errorMessage}... Reverting todo...</p>
+            <p>{todoState.errorMessage}... Reverting todo...</p>
           </div>
-          <button onClick={() => setErrorMessage('')}>
+          <button onClick={() => dispatch({ type: todoActions.clearError })}>
             Dismiss Error Message
           </button>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,15 +11,11 @@ import {
   reducer as todosReducer,
   actions as todoActions,
   initialState as initialTodosState,
-} from './reducers/todos.reducer';
+} from './features/reducers/todos.reducer.js';
 
 function App() {
   // Reducer state (todoList, isLoading, isSaving, errorMessage)
   const [todoState, dispatch] = useReducer(todosReducer, initialTodosState);
-
-  const [sortField, setSortField] = useState('createdTime');
-  const [sortDirection, setSortDirection] = useState('desc');
-  const [queryString, setQueryString] = useState('');
 
   const url = `https://api.airtable.com/v0/${import.meta.env.VITE_BASE_ID}/${import.meta.env.VITE_TABLE_NAME}`;
   const token = `Bearer ${import.meta.env.VITE_PAT}`;
@@ -27,16 +23,21 @@ function App() {
   // URL for listing (GET) with sort/filter
   const encodeUrl = useCallback(() => {
     const u = new URL(url);
-    u.searchParams.set('sort[0][field]', sortField);
-    u.searchParams.set('sort[0][direction]', sortDirection);
+    u.searchParams.set('sort[0][field]', todoState.sortField);
+    u.searchParams.set('sort[0][direction]', todoState.sortDirection);
 
-    if (queryString.trim()) {
-      const safe = queryString.replaceAll('"', '\\"');
+    if (todoState.queryString.trim()) {
+      const safe = todoState.queryString.replaceAll('"', '\\"');
       const formula = `SEARCH("${safe}", {title})`;
       u.searchParams.set('filterByFormula', formula);
     }
     return u.toString();
-  }, [url, sortField, sortDirection, queryString]);
+  }, [
+    url,
+    todoState.sortField,
+    todoState.sortDirection,
+    todoState.queryString,
+  ]);
 
   // Load todos (pessimistic)
   useEffect(() => {
@@ -187,12 +188,18 @@ function App() {
 
       <hr />
       <TodosViewForm
-        sortField={sortField}
-        setSortField={setSortField}
-        sortDirection={sortDirection}
-        setSortDirection={setSortDirection}
-        queryString={queryString}
-        setQueryString={setQueryString}
+        sortField={todoState.sortField}
+        setSortField={(v) =>
+          dispatch({ type: todoActions.setSortField, value: v })
+        }
+        sortDirection={todoState.sortDirection}
+        setSortDirection={(v) =>
+          dispatch({ type: todoActions.setSortDirection, value: v })
+        }
+        queryString={todoState.queryString}
+        setQueryString={(v) =>
+          dispatch({ type: todoActions.setQueryString, value: v })
+        }
       />
 
       {todoState.errorMessage && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useReducer } from 'react';
 import './App.css';
 import styles from './App.module.css';
 import TodoForm from './features/shared/TodoForm';
@@ -6,8 +6,14 @@ import TodoList from './features/TodoList/TodoList';
 import TodosViewForm from './features/TodosViewForm';
 import logo from './assets/logo.svg';
 import errorIcon from './assets/error.svg';
+import {
+  reducer as todosReducer,
+  actions as todoActions,
+  initialState as initialTodosState,
+} from './reducers/todos.reducer';
 
 function App() {
+  const [todoState, dispatch] = useReducer(todosReducer, initialTodosState);
   const [todoList, setTodoList] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,17 @@ import TodoList from './features/TodoList/TodoList';
 import TodosViewForm from './features/TodosViewForm';
 import logo from './assets/logo.svg';
 import errorIcon from './assets/error.svg';
+
 import {
   reducer as todosReducer,
   actions as todoActions,
   initialState as initialTodosState,
-} from './features/reducers/todos.reducer';
+} from './features/reducers/todos.reducer.js';
 
 function App() {
+  // Reducer state (todoList, isLoading, isSaving, errorMessage)
   const [todoState, dispatch] = useReducer(todosReducer, initialTodosState);
+
   const [todoList, setTodoList] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -122,6 +125,12 @@ function App() {
     if (!editedTodo) return;
 
     const originalTodo = { ...editedTodo };
+    const optimistic = {
+      id,
+      title: newTitle,
+      isCompleted: editedTodo.isCompleted,
+    };
+    dispatch({ type: todoActions.updateTodo, editedTodo: optimistic });
 
     setTodoList((prev) =>
       prev.map((t) => (t.id === id ? { ...t, title: newTitle } : t))
@@ -153,6 +162,7 @@ function App() {
       if (!resp.ok)
         throw new Error('NetworkError when attempting to fetch resource.');
     } catch (error) {
+      dispatch({ type: todoActions.revertTodo, originalTodo, error });
       setErrorMessage(error instanceof Error ? error.message : String(error));
       setTodoList((prev) => prev.map((t) => (t.id === id ? originalTodo : t)));
     }
@@ -163,6 +173,7 @@ function App() {
     if (!target) return;
 
     const originalTodo = { ...target };
+    dispatch({ type: todoActions.completeTodo, id });
 
     setTodoList((prev) =>
       prev.map((t) => (t.id === id ? { ...t, isCompleted: true } : t))
@@ -194,6 +205,7 @@ function App() {
       if (!resp.ok)
         throw new Error('NetworkError when attempting to fetch resource.');
     } catch (error) {
+      dispatch({ type: todoActions.revertTodo, originalTodo, error });
       setErrorMessage(error instanceof Error ? error.message : String(error));
       setTodoList((prev) => prev.map((t) => (t.id === id ? originalTodo : t)));
     }

--- a/src/features/reducers/todos.reducer.js
+++ b/src/features/reducers/todos.reducer.js
@@ -1,0 +1,115 @@
+export const initialState = {
+  todoList: [],
+  isLoading: false,
+  isSaving: false,
+  errorMessage: '',
+};
+
+export const actions = {
+  // useEffect (load)
+  fetchTodos: 'fetchTodos',
+  loadTodos: 'loadTodos',
+  setLoadError: 'setLoadError',
+
+  // addTodo (pessimistic)
+  startRequest: 'startRequest',
+  addTodo: 'addTodo',
+  endRequest: 'endRequest',
+
+  // optimistic updates
+  updateTodo: 'updateTodo',
+  completeTodo: 'completeTodo',
+  revertTodo: 'revertTodo',
+
+  // dismiss error
+  clearError: 'clearError',
+};
+
+export function reducer(state = initialState, action) {
+  switch (action.type) {
+    case actions.fetchTodos:
+      return { ...state, isLoading: true };
+
+    case actions.loadTodos: {
+      const mapped = (action.records ?? []).map((record) => ({
+        id: record.id,
+        title: record.fields?.title ?? '',
+        isCompleted: !!record.fields?.isCompleted,
+      }));
+      return { ...state, todoList: mapped, isLoading: false };
+    }
+
+    case actions.setLoadError:
+      return {
+        ...state,
+        errorMessage:
+          action.error?.message ??
+          (typeof action.error === 'string' ? action.error : 'Unknown error'),
+        isLoading: false,
+      };
+
+    case actions.startRequest:
+      return { ...state, isSaving: true };
+
+    case actions.addTodo: {
+      const first = (action.records ?? [])[0];
+      const savedTodo = first
+        ? {
+            id: first.id,
+            title: first.fields?.title ?? '',
+            isCompleted: !!first.fields?.isCompleted,
+          }
+        : null;
+      return {
+        ...state,
+        todoList: savedTodo ? [...state.todoList, savedTodo] : state.todoList,
+        isSaving: false,
+      };
+    }
+
+    case actions.endRequest:
+      return { ...state, isLoading: false, isSaving: false };
+
+    case actions.revertTodo:
+      // make revert use same path as update
+      // eslint-disable-next-line no-param-reassign
+      action.editedTodo = action.originalTodo;
+    // eslint-disable-next-line no-fallthrough
+    case actions.updateTodo: {
+      const edited = action.editedTodo;
+      if (!edited || !edited.id) return state;
+
+      const updatedTodos = state.todoList.map((t) =>
+        t.id === edited.id ? { ...t, ...edited } : t
+      );
+
+      const updatedState = { ...state, todoList: updatedTodos };
+      if (action.error) {
+        updatedState.errorMessage =
+          action.error?.message ??
+          (typeof action.error === 'string' ? action.error : 'Unknown error');
+      }
+      return updatedState;
+    }
+
+    case actions.completeTodo: {
+      const id = action.id;
+      const updatedTodos = state.todoList.map((t) =>
+        t.id === id ? { ...t, isCompleted: true } : t
+      );
+      const updatedState = { ...state, todoList: updatedTodos };
+      if (action.error) {
+        updatedState.errorMessage =
+          action.error?.message ??
+          (typeof action.error === 'string' ? action.error : 'Unknown error');
+      }
+      return updatedState;
+    }
+
+    case actions.clearError:
+      return { ...state, errorMessage: '' };
+
+    default:
+      return state;
+  }
+}

--- a/src/features/reducers/todos.reducer.js
+++ b/src/features/reducers/todos.reducer.js
@@ -3,6 +3,9 @@ export const initialState = {
   isLoading: false,
   isSaving: false,
   errorMessage: '',
+  sortDirection: 'desc',
+  sortField: 'createdTime',
+  queryString: '',
 };
 
 export const actions = {
@@ -23,6 +26,9 @@ export const actions = {
 
   // dismiss error
   clearError: 'clearError',
+  setSortField: 'setSortField',
+  setSortDirection: 'setSortDirection',
+  setQueryString: 'setQueryString',
 };
 
 export function reducer(state = initialState, action) {
@@ -108,6 +114,13 @@ export function reducer(state = initialState, action) {
 
     case actions.clearError:
       return { ...state, errorMessage: '' };
+
+    case actions.setSortField:
+      return { ...state, sortField: action.value };
+    case actions.setSortDirection:
+      return { ...state, sortDirection: action.value };
+    case actions.setQueryString:
+      return { ...state, queryString: action.value };
 
     default:
       return state;


### PR DESCRIPTION
- Add `src/reducers/todos.reducer.js` with `initialState` and exported `actions`.
- Implement reducer cases: `fetch/load/setLoadError`, `startRequest/addTodo/endRequest`, `update/complete/revert`, `clearError`.
- Wire `useReducer` in `App`; expose `todoState` + `dispatch`.
- Replace `setState` calls with `dispatch` in load (pessimistic), add (pessimistic), and update/complete (optimistic + revert on failure).
- UI reads `todoList`, `isLoading`, `isSaving`, `errorMessage` from reducer; Dismiss button dispatches `clearError`.
- Stretch: move `sortField`, `sortDirection`, `queryString` into reducer.
- Update `encodeUrl` to use reducer state; pass dispatch-wrapped setters to `TodosViewForm`.
- Behavior unchanged; sorting/filter + debounce and error handling preserved.
